### PR TITLE
feat: add pre-commit hooks to format files + conventional commits

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -182,7 +182,7 @@ csharp_preserve_single_line_statements = true
 # Naming rules
 
 dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.severity = suggestion
-dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.symbols = types_and_namespaces, interfaces
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.symbols = types_and_namespaces
 dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.style = pascalcase
 
 dotnet_naming_rule.type_parameters_should_be_tpascalcase.severity = suggestion
@@ -287,7 +287,7 @@ dotnet_naming_symbols.private_static_fields.applicable_kinds = field
 dotnet_naming_symbols.private_static_fields.applicable_accessibilities = private, protected, protected_internal, private_protected
 dotnet_naming_symbols.private_static_fields.required_modifiers = static
 
-dotnet_naming_symbols.types_and_namespaces.applicable_kinds = namespace, class, struct, interface, enum
+dotnet_naming_symbols.types_and_namespaces.applicable_kinds = namespace, class, struct, interface, enum, record
 dotnet_naming_symbols.types_and_namespaces.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
 dotnet_naming_symbols.types_and_namespaces.required_modifiers = 
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         name: dotnet-test
         language: system 
         stages: [pre-push]
-        entry: dotnet test
+        entry: dotnet test CsharpBasicSkeleton.sln
         types_or: ["c#"]
 -   repo: https://github.com/commitizen-tools/commitizen
     rev: 3.5.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,11 +16,6 @@ repos:
         entry: dotnet format
         args: ["--include"]
         types_or: ["c#"]
-    -   id: test
-        name: dotnet test
-        language: system
-        entry: dotnet test .
-        types_or: ["c#"]
 -   repo: https://github.com/commitizen-tools/commitizen
     rev: 3.5.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,14 +13,13 @@ repos:
         name: dotnet-format
         language: system
         stages: [pre-commit]
-        entry: format
+        entry: dotnet format
         args: ["--include"]
         types_or: ["c#"]
-    -   id: dotnet
-        name: dotnet-test
-        language: dotnet 
-        stages: [pre-push]
-        entry: test
+    -   id: test
+        name: dotnet test
+        language: system
+        entry: dotnet test .
         types_or: ["c#"]
 -   repo: https://github.com/commitizen-tools/commitizen
     rev: 3.5.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,8 @@ repos:
         name: dotnet-test
         language: system 
         stages: [pre-push]
-        entry: dotnet test CsharpBasicSkeleton.sln
+        entry: dotnet test
+        args: ["./CsharpBasicSkeleton.sln"]
         types_or: ["c#"]
 -   repo: https://github.com/commitizen-tools/commitizen
     rev: 3.5.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: check-yaml
+        stages: [pre-commit]
+-   repo: local
+    hooks:
+    #Use dotnet format already installed on your machine
+    -   id: dotnet-format
+        name: dotnet-format
+        language: system
+        stages: [pre-commit]
+        entry: dotnet format --include 
+        types_or: ["c#"]
+    -   id: dotnet-test
+        name: dotnet-test
+        language: system 
+        stages: [pre-push]
+        entry: dotnet test
+        types_or: ["c#"]
+-   repo: https://github.com/commitizen-tools/commitizen
+    rev: 3.5.2
+    hooks:
+    -   id: commitizen
+        stages: [commit-msg]
+    -   id: commitizen-branch
+        stages: [push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,14 +13,14 @@ repos:
         name: dotnet-format
         language: system
         stages: [pre-commit]
-        entry: dotnet format --include 
+        entry: format
+        args: ["--include"]
         types_or: ["c#"]
-    -   id: dotnet-test
+    -   id: dotnet
         name: dotnet-test
-        language: system 
+        language: dotnet 
         stages: [pre-push]
-        entry: dotnet test
-        args: ["./CsharpBasicSkeleton.sln"]
+        entry: test
         types_or: ["c#"]
 -   repo: https://github.com/commitizen-tools/commitizen
     rev: 3.5.2

--- a/.template_config/template.json
+++ b/.template_config/template.json
@@ -21,7 +21,7 @@
 				{
 					"exclude": [
 						".template_config/**",
-						".git"
+						".git/**"
 					]
 				}
 			]

--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ This template will create:
 - A `*/Domain` project to write your "productive" code.
 - A working test using a reference to `*/Domain` project.
 - A `.gitignore` file to just include relevant files in your repository.
+- A `pre-commit` configuration in order to follow conventional-commits and formatting c# files.
 
 ## Prerequisite
-- [.NET7 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/7.0).
+- [.NET7 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/7.0)
+- [pre-commit](https://pre-commit.com/index.html#install)
 
 ## How To Start
 
@@ -39,10 +41,11 @@ You have two main ways of starting a project from this template:
 > While first is easier from GitHub interface, second one allow you to have a local way of creating as many projects you want with this structure just by installing the template the first time.
 
 ### Working with the workspace 
- 
-1. Build the project: `dotnet build`
-2. Run tests: `dotnet test`. 
-3. Start coding!
+
+1. Install pre-commit hooks with: `pre-commit install --install-hooks -t pre-commit -t commit-msg`
+2. Build the project: `dotnet build`
+3. Run tests: `dotnet test`. 
+4. Start coding!
 
 ## About
 
@@ -65,4 +68,3 @@ The MIT License (MIT). Please see [License File][link-license] for more informat
 [link-readme]: README.md
 [link-author]: https://github.com/CodelyTV
 [link-contributors]: ../../contributors
-

--- a/src/CsharpBasicSkeleton/Greeter.cs
+++ b/src/CsharpBasicSkeleton/Greeter.cs
@@ -4,6 +4,6 @@ public static class Greeter
 {
 	public static string Greet(string name)
 	{
-		return $"Hello {name}";
+		return $"Hello {name}!";
 	}
 }

--- a/tests/CsharpBasicSkeleton.Tests/GreeterShould.cs
+++ b/tests/CsharpBasicSkeleton.Tests/GreeterShould.cs
@@ -7,6 +7,6 @@ public class GreeterShould
 	[Test]
 	public void Greet_using_the_name()
 	{
-		Greeter.Greet("Codelier").Should().Be("Hello Codelier");
+		Greeter.Greet("Codelier").Should().Be("Hello Codelier!");
 	}
 }


### PR DESCRIPTION
## What this does?
Just adding the possibility of installing [pre-commit hooks](https://pre-commit.com/index.html#intro) in order to follow conventional commits and enforce c# files to follow the rules in `.editorconfig`.

## What changed?
- Now when starting the project you can run `pre-commit install --install-hooks -t pre-commit -t commit-msg` after initializing the git repository. This would allow git to use the hooks defined in the new file `.pre-commit-config.yaml`
  - Using `dotnet format` in order to enforce coding conventions in `.editorconfig`.
  - Using `commitizen` to enforce conventional commits convention while committing. 
- Adjusting some rules from `.editorconfig`
  - Enforcing namespace to match with directory files



